### PR TITLE
fix: update version in  to v1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rsult"
-version = "0.1.0"
+version = "1.0.1"
 description = "Rust like `Result[T, E]` support for python!"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Previous release contained the wrong version number in the `pyproject.toml` file. This commit updates that version number to match the version it will be released under `v1.0.1`.